### PR TITLE
update npm link permanently

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node package manager benchmark
 
-This benchmark compares the performance of [npm](https://github.com/npm/npm), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
+This benchmark compares the performance of [npm](https://github.com/npm/cli), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
 
 ## React app
 

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ async function run () {
       writeFile('README.md', stripIndents`
         # Node package manager benchmark
 
-        This benchmark compares the performance of [npm](https://github.com/npm/npm), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
+        This benchmark compares the performance of [npm](https://github.com/npm/cli), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
 
         ${sections.join('\n\n')}`, 'utf8')
     ]


### PR DESCRIPTION
In #20 the link in `README.md` was updated directly. But `index.js` overwrites `README.md` whenever the benchmark is run. This is a more permanent fix.

Thanks to @Kishan08 for the reminder!