### PR TITLE
Make graphs look good on all browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node package manager benchmark
 
-This benchmark compares the performance of [npm](https://github.com/npm/npm), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
+This benchmark compares the performance of [npm](https://github.com/npm/cli), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
 
 ## React app
 

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ async function run () {
       writeFile('README.md', stripIndents`
         # Node package manager benchmark
 
-        This benchmark compares the performance of [npm](https://github.com/npm/npm), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
+        This benchmark compares the performance of [npm](https://github.com/npm/cli), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
 
         ${sections.join('\n\n')}`, 'utf8')
     ]

--- a/lib/benchmarkFixture.js
+++ b/lib/benchmarkFixture.js
@@ -15,7 +15,7 @@ const TMP = path.join(BASEDIR, '.tmp')
 const lockfileName = {
   npm: 'package-lock.json',
   pnpm: 'shrinkwrap.yaml',
-  yarn: 'yarn.lock',
+  yarn: 'yarn.lock'
 }
 
 const env = createEnv()

--- a/lib/generateSvg.js
+++ b/lib/generateSvg.js
@@ -70,14 +70,14 @@ module.exports = (resultArrays, pms, tests) => {
     const baseline = 'hanging'
     const anchor = 'middle'
     let textY = y + radius + 1
-    svgStr += `  <text x="${x}" y="${textY}" font-size="${fontSize}" font-family="${fontFamily}" alignment-baseline="${baseline}" text-anchor="${anchor}">${pm}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${textY}" font-size="${fontSize}" font-family="${fontFamily}" dominant-baseline="${baseline}" text-anchor="${anchor}">${pm}</text>` + '\n'
 
     // add version under name
     const pmVersion = require(`${pm}/package.json`).version
     const text = `v${pmVersion}`
     fontSize = 3
     textY += 5
-    svgStr += `  <text x="${x}" y="${textY}" font-size="${fontSize}" font-family="${fontFamily}" alignment-baseline="${baseline}" text-anchor="${anchor}">${text}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${textY}" font-size="${fontSize}" font-family="${fontFamily}" dominant-baseline="${baseline}" text-anchor="${anchor}">${text}</text>` + '\n'
   })
 
   const graphLines = [
@@ -120,7 +120,7 @@ module.exports = (resultArrays, pms, tests) => {
     // add numbers below the graph lines
     const baseline = 'hanging'
     y = y2 + 1
-    svgStr += `  <text x="${x}" y="${y}" fill="${textColor}" font-size="${fontSize}" font-family="${fontFamily}" text-anchor="${anchor}" alignment-baseline="${baseline}">${number}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${y}" fill="${textColor}" font-size="${fontSize}" font-family="${fontFamily}" text-anchor="${anchor}" dominant-baseline="${baseline}">${number}</text>` + '\n'
   })
 
   // add axis explanation
@@ -169,7 +169,7 @@ module.exports = (resultArrays, pms, tests) => {
         // get y position for property based on how much properties there are
         ((properties.length - (indexP + 1)) / 2) * ySpacing +
         ySpacing * indexP / 2
-      svgStr += `  <text x="${x}" y="${y}" font-size="${fontSize}" font-family="${fontFamily}" alignment-baseline="${baseline}" text-anchor="${anchor}">${property}</text>` + '\n'
+      svgStr += `  <text x="${x}" y="${y}" font-size="${fontSize}" font-family="${fontFamily}" dominant-baseline="${baseline}" text-anchor="${anchor}">${property}</text>` + '\n'
     })
   })
 

--- a/lib/generateSvg.js
+++ b/lib/generateSvg.js
@@ -49,9 +49,25 @@ module.exports = (resultArrays, pms, tests) => {
   // up to the nearest number divisible by 5
   const limit = Math.ceil(max / 5) * 5
   const ratio = graph.w / limit
+  const styles = {
+    font: '.font { font-family: sans-serif; }',
+    s3: '.s3 { font-size: 3px; }',
+    s4: '.s4 { font-size: 4px; }',
+    s5: '.s5 { font-size: 5px; }',
+    line: '.line { stroke: #cacaca; }',
+    width: '.width { stroke-width: 0.5; }',
+    text: '.text { fill: #888; }'
+  }
 
   svgStr += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" '
   svgStr += `viewBox="${vb.x} ${vb.y} ${vb.w} ${vb.h}">` + '\n'
+
+  // add styles
+  svgStr += '  <style>' + '\n'
+  Object.values(styles).forEach((style) => {
+    svgStr += `    ${style}` + '\n'
+  })
+  svgStr += '  </style>' + '\n'
 
   // uncomment to color the entire view box for debugging
   // svgStr += `<rect x="${vb.x}" y="${vb.y}" width="${vb.w}" height="${vb.h}" fill="${'#eaeaea'}"></rect>` + '\n'
@@ -65,19 +81,16 @@ module.exports = (resultArrays, pms, tests) => {
     svgStr += `  <circle cx="${x}" cy="${y}" r="${radius}" fill="${colors[index]}"></circle>` + '\n'
 
     // add name under circle
-    let fontSize = 4
-    const fontFamily = 'system-ui'
     const baseline = 'hanging'
     const anchor = 'middle'
     let textY = y + radius + 1
-    svgStr += `  <text x="${x}" y="${textY}" font-size="${fontSize}" font-family="${fontFamily}" dominant-baseline="${baseline}" text-anchor="${anchor}">${pm}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${textY}" class="font s4" dominant-baseline="${baseline}" text-anchor="${anchor}">${pm}</text>` + '\n'
 
     // add version under name
     const pmVersion = require(`${pm}/package.json`).version
     const text = `v${pmVersion}`
-    fontSize = 3
     textY += 5
-    svgStr += `  <text x="${x}" y="${textY}" font-size="${fontSize}" font-family="${fontFamily}" dominant-baseline="${baseline}" text-anchor="${anchor}">${text}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${textY}" class="font s3" dominant-baseline="${baseline}" text-anchor="${anchor}">${text}</text>` + '\n'
   })
 
   const graphLines = [
@@ -93,13 +106,12 @@ module.exports = (resultArrays, pms, tests) => {
   // draw graph lines
   graphLines.forEach((graphLine, index) => {
     const isBaseLine = index === 0
-    const lineColor = '#cacaca'
-    const strokeWidth = isBaseLine
-      ? 1
-      : 0.5
+    const compositeClass = isBaseLine
+      ? 'line'
+      : 'line width'
     const y1 = graph.y - separation
     const y2 = y1 + graph.h
-    const line = `  <line x1="${graphLine}" y1="${y1}" x2="${graphLine}" y2="${y2}" stroke-width="${strokeWidth}" stroke="${lineColor}"></line>` + '\n'
+    const line = `  <line x1="${graphLine}" y1="${y1}" x2="${graphLine}" y2="${y2}" class="${compositeClass}"></line>` + '\n'
     // add base graph line after the bars are drawn so that it is drawn over the bars
     if (isBaseLine) {
       baseGraphLine = line
@@ -108,32 +120,26 @@ module.exports = (resultArrays, pms, tests) => {
     }
 
     // add numbers above the graph lines
-    const textColor = '#888'
-    const fontSize = 5
-    const fontFamily = 'system-ui'
     const anchor = 'middle'
     const x = graphLine
     let y = graph.y - 7
     const number = limit * (index / (graphLines.length - 1))
-    svgStr += `  <text x="${x}" y="${y}" fill="${textColor}" font-size="${fontSize}" font-family="${fontFamily}" text-anchor="${anchor}">${number}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${y}" class="font s5 text" text-anchor="${anchor}">${number}</text>` + '\n'
 
     // add numbers below the graph lines
     const baseline = 'hanging'
     y = y2 + 1
-    svgStr += `  <text x="${x}" y="${y}" fill="${textColor}" font-size="${fontSize}" font-family="${fontFamily}" text-anchor="${anchor}" dominant-baseline="${baseline}">${number}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${y}" class="font s5 text" text-anchor="${anchor}" dominant-baseline="${baseline}">${number}</text>` + '\n'
   })
 
   // add axis explanation
   ;(() => {
     const text = 'Installation time in seconds (lower is better)'
-    const color = '#888'
-    const fontSize = 4
-    const fontFamily = 'system-ui'
     const anchor = 'end'
     const fontStyle = 'italic'
     const x = graph.x + graph.w
     const y = graph.y - 15
-    svgStr += `  <text x="${x}" y="${y}" font-size="${fontSize}" font-family="${fontFamily}" font-style="${fontStyle}" text-anchor="${anchor}" fill="${color}">${text}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${y}" class="font s4 text" font-style="${fontStyle}" text-anchor="${anchor}">${text}</text>` + '\n'
   })()
 
   // draw results as bars
@@ -155,8 +161,6 @@ module.exports = (resultArrays, pms, tests) => {
   // next to each bar group specify the properties of the test
   tests.forEach((properties, indexT) => {
     properties.forEach((property, indexP) => {
-      const fontSize = 4
-      const fontFamily = 'system-ui'
       const baseline = 'middle'
       const anchor = 'end'
       const ySpacing = 4
@@ -169,20 +173,17 @@ module.exports = (resultArrays, pms, tests) => {
         // get y position for property based on how much properties there are
         ((properties.length - (indexP + 1)) / 2) * ySpacing +
         ySpacing * indexP / 2
-      svgStr += `  <text x="${x}" y="${y}" font-size="${fontSize}" font-family="${fontFamily}" dominant-baseline="${baseline}" text-anchor="${anchor}">${property}</text>` + '\n'
+      svgStr += `  <text x="${x}" y="${y}" class="font s4" dominant-baseline="${baseline}" text-anchor="${anchor}">${property}</text>` + '\n'
     })
   })
 
   // add node version
   ;(() => {
     const text = `Tests were run using Node.js ${process.version}`
-    const color = '#888'
-    const fontSize = 4
-    const fontFamily = 'system-ui'
     const anchor = 'end'
     const x = graph.x + graph.w
     const y = vb.h - 2
-    svgStr += `  <text x="${x}" y="${y}" font-size="${fontSize}" font-family="${fontFamily}" text-anchor="${anchor}" fill="${color}">${text}</text>` + '\n'
+    svgStr += `  <text x="${x}" y="${y}" class="font s4 text" text-anchor="${anchor}">${text}</text>` + '\n'
   })()
 
   svgStr += `</svg>` + '\n'

--- a/lib/generateSvg.js
+++ b/lib/generateSvg.js
@@ -81,16 +81,15 @@ module.exports = (resultArrays, pms, tests) => {
     svgStr += `  <circle cx="${x}" cy="${y}" r="${radius}" fill="${colors[index]}"></circle>` + '\n'
 
     // add name under circle
-    const baseline = 'hanging'
     const anchor = 'middle'
-    let textY = y + radius + 1
-    svgStr += `  <text x="${x}" y="${textY}" class="font s4" dominant-baseline="${baseline}" text-anchor="${anchor}">${pm}</text>` + '\n'
+    let textY = y + radius + 4
+    svgStr += `  <text x="${x}" y="${textY}" class="font s4" text-anchor="${anchor}">${pm}</text>` + '\n'
 
     // add version under name
     const pmVersion = require(`${pm}/package.json`).version
     const text = `v${pmVersion}`
-    textY += 5
-    svgStr += `  <text x="${x}" y="${textY}" class="font s3" dominant-baseline="${baseline}" text-anchor="${anchor}">${text}</text>` + '\n'
+    textY += 4
+    svgStr += `  <text x="${x}" y="${textY}" class="font s3" text-anchor="${anchor}">${text}</text>` + '\n'
   })
 
   const graphLines = [
@@ -127,9 +126,8 @@ module.exports = (resultArrays, pms, tests) => {
     svgStr += `  <text x="${x}" y="${y}" class="font s5 text" text-anchor="${anchor}">${number}</text>` + '\n'
 
     // add numbers below the graph lines
-    const baseline = 'hanging'
-    y = y2 + 1
-    svgStr += `  <text x="${x}" y="${y}" class="font s5 text" text-anchor="${anchor}" dominant-baseline="${baseline}">${number}</text>` + '\n'
+    y = y2 + 5
+    svgStr += `  <text x="${x}" y="${y}" class="font s5 text" text-anchor="${anchor}">${number}</text>` + '\n'
   })
 
   // add axis explanation

--- a/results/imgs/alotta-files.svg
+++ b/results/imgs/alotta-files.svg
@@ -1,31 +1,40 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 237">
+  <style>
+    .font { font-family: sans-serif; }
+    .s3 { font-size: 3px; }
+    .s4 { font-size: 4px; }
+    .s5 { font-size: 5px; }
+    .line { stroke: #cacaca; }
+    .width { stroke-width: 0.5; }
+    .text { fill: #888; }
+  </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
+  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
+  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v2.13.0</text>
-  <text x="40" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">0</text>
-  <text x="40" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">0</text>
-  <line x1="90" y1="31" x2="90" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="90" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">7</text>
-  <text x="90" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">7</text>
-  <line x1="140" y1="31" x2="140" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="140" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">14</text>
-  <text x="140" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">14</text>
-  <line x1="190" y1="31" x2="190" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="190" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">21</text>
-  <text x="190" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">21</text>
-  <line x1="240" y1="31" x2="240" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="240" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">28</text>
-  <text x="240" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">28</text>
-  <line x1="290" y1="31" x2="290" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="290" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">35</text>
-  <text x="290" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">35</text>
-  <text x="290" y="20" font-size="4" font-family="system-ui" font-style="italic" text-anchor="end" fill="#888">Installation time in seconds (lower is better)</text>
+  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
+  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
+  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
+  <text x="90" y="28" class="font s5 text" text-anchor="middle">7</text>
+  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">7</text>
+  <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
+  <text x="140" y="28" class="font s5 text" text-anchor="middle">14</text>
+  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">14</text>
+  <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
+  <text x="190" y="28" class="font s5 text" text-anchor="middle">21</text>
+  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">21</text>
+  <line x1="240" y1="31" x2="240" y2="223" class="line width"></line>
+  <text x="240" y="28" class="font s5 text" text-anchor="middle">28</text>
+  <text x="240" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">28</text>
+  <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
+  <text x="290" y="28" class="font s5 text" text-anchor="middle">35</text>
+  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">35</text>
+  <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="228" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="247" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="48" width="142" height="6" fill="#fbae00" rx="1" ry="1"></rect>
@@ -50,19 +59,19 @@
   <rect x="40" y="199.5" width="57" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="206" width="241" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="212.5" width="121" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <line x1="40" y1="31" x2="40" y2="223" stroke-width="1" stroke="#cacaca"></line>
-  <text x="38" y="44.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">clean install</text>
-  <text x="38" y="64" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="68" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="72" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="89.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="93.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="115" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="138.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="160" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="164" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="183.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="187.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="209" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="290" y="235" font-size="4" font-family="system-ui" text-anchor="end" fill="#888">Tests were run using Node.js v10.6.0</text>
+  <line x1="40" y1="31" x2="40" y2="223" class="line"></line>
+  <text x="38" y="44.5" class="font s4" dominant-baseline="middle" text-anchor="end">clean install</text>
+  <text x="38" y="64" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="68" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="72" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="89.5" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="93.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="115" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="138.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="160" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="164" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="183.5" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="187.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="209" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="290" y="235" class="font s4 text" text-anchor="end">Tests were run using Node.js v10.6.0</text>
 </svg>

--- a/results/imgs/alotta-files.svg
+++ b/results/imgs/alotta-files.svg
@@ -9,31 +9,31 @@
     .text { fill: #888; }
   </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="14" class="font s4" text-anchor="middle">npm</text>
+  <text x="44" y="18" class="font s3" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="14" class="font s4" text-anchor="middle">yarn</text>
+  <text x="56" y="18" class="font s3" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="68" y="14" class="font s4" text-anchor="middle">pnpm</text>
+  <text x="68" y="18" class="font s3" text-anchor="middle">v2.13.0</text>
   <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
-  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <text x="40" y="228" class="font s5 text" text-anchor="middle">0</text>
   <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
   <text x="90" y="28" class="font s5 text" text-anchor="middle">7</text>
-  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">7</text>
+  <text x="90" y="228" class="font s5 text" text-anchor="middle">7</text>
   <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
   <text x="140" y="28" class="font s5 text" text-anchor="middle">14</text>
-  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">14</text>
+  <text x="140" y="228" class="font s5 text" text-anchor="middle">14</text>
   <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
   <text x="190" y="28" class="font s5 text" text-anchor="middle">21</text>
-  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">21</text>
+  <text x="190" y="228" class="font s5 text" text-anchor="middle">21</text>
   <line x1="240" y1="31" x2="240" y2="223" class="line width"></line>
   <text x="240" y="28" class="font s5 text" text-anchor="middle">28</text>
-  <text x="240" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">28</text>
+  <text x="240" y="228" class="font s5 text" text-anchor="middle">28</text>
   <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
   <text x="290" y="28" class="font s5 text" text-anchor="middle">35</text>
-  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">35</text>
+  <text x="290" y="228" class="font s5 text" text-anchor="middle">35</text>
   <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="228" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="247" height="6" fill="#248ebd" rx="1" ry="1"></rect>

--- a/results/imgs/angular-quickstart.svg
+++ b/results/imgs/angular-quickstart.svg
@@ -1,31 +1,40 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 237">
+  <style>
+    .font { font-family: sans-serif; }
+    .s3 { font-size: 3px; }
+    .s4 { font-size: 4px; }
+    .s5 { font-size: 5px; }
+    .line { stroke: #cacaca; }
+    .width { stroke-width: 0.5; }
+    .text { fill: #888; }
+  </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
+  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
+  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v2.13.0</text>
-  <text x="40" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">0</text>
-  <text x="40" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">0</text>
-  <line x1="90" y1="31" x2="90" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="90" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">6</text>
-  <text x="90" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">6</text>
-  <line x1="140" y1="31" x2="140" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="140" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">12</text>
-  <text x="140" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">12</text>
-  <line x1="190" y1="31" x2="190" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="190" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">18</text>
-  <text x="190" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">18</text>
-  <line x1="240.00000000000003" y1="31" x2="240.00000000000003" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="240.00000000000003" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">24</text>
-  <text x="240.00000000000003" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">24</text>
-  <line x1="290" y1="31" x2="290" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="290" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">30</text>
-  <text x="290" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">30</text>
-  <text x="290" y="20" font-size="4" font-family="system-ui" font-style="italic" text-anchor="end" fill="#888">Installation time in seconds (lower is better)</text>
+  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
+  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
+  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
+  <text x="90" y="28" class="font s5 text" text-anchor="middle">6</text>
+  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">6</text>
+  <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
+  <text x="140" y="28" class="font s5 text" text-anchor="middle">12</text>
+  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">12</text>
+  <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
+  <text x="190" y="28" class="font s5 text" text-anchor="middle">18</text>
+  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">18</text>
+  <line x1="240.00000000000003" y1="31" x2="240.00000000000003" y2="223" class="line width"></line>
+  <text x="240.00000000000003" y="28" class="font s5 text" text-anchor="middle">24</text>
+  <text x="240.00000000000003" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">24</text>
+  <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
+  <text x="290" y="28" class="font s5 text" text-anchor="middle">30</text>
+  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">30</text>
+  <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="206" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="227" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="48" width="170" height="6" fill="#fbae00" rx="1" ry="1"></rect>
@@ -50,19 +59,19 @@
   <rect x="40" y="199.5" width="66" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="206" width="226" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="212.5" width="157" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <line x1="40" y1="31" x2="40" y2="223" stroke-width="1" stroke="#cacaca"></line>
-  <text x="38" y="44.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">clean install</text>
-  <text x="38" y="64" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="68" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="72" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="89.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="93.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="115" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="138.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="160" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="164" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="183.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="187.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="209" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="290" y="235" font-size="4" font-family="system-ui" text-anchor="end" fill="#888">Tests were run using Node.js v10.6.0</text>
+  <line x1="40" y1="31" x2="40" y2="223" class="line"></line>
+  <text x="38" y="44.5" class="font s4" dominant-baseline="middle" text-anchor="end">clean install</text>
+  <text x="38" y="64" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="68" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="72" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="89.5" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="93.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="115" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="138.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="160" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="164" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="183.5" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="187.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="209" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="290" y="235" class="font s4 text" text-anchor="end">Tests were run using Node.js v10.6.0</text>
 </svg>

--- a/results/imgs/angular-quickstart.svg
+++ b/results/imgs/angular-quickstart.svg
@@ -9,31 +9,31 @@
     .text { fill: #888; }
   </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="14" class="font s4" text-anchor="middle">npm</text>
+  <text x="44" y="18" class="font s3" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="14" class="font s4" text-anchor="middle">yarn</text>
+  <text x="56" y="18" class="font s3" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="68" y="14" class="font s4" text-anchor="middle">pnpm</text>
+  <text x="68" y="18" class="font s3" text-anchor="middle">v2.13.0</text>
   <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
-  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <text x="40" y="228" class="font s5 text" text-anchor="middle">0</text>
   <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
   <text x="90" y="28" class="font s5 text" text-anchor="middle">6</text>
-  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">6</text>
+  <text x="90" y="228" class="font s5 text" text-anchor="middle">6</text>
   <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
   <text x="140" y="28" class="font s5 text" text-anchor="middle">12</text>
-  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">12</text>
+  <text x="140" y="228" class="font s5 text" text-anchor="middle">12</text>
   <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
   <text x="190" y="28" class="font s5 text" text-anchor="middle">18</text>
-  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">18</text>
+  <text x="190" y="228" class="font s5 text" text-anchor="middle">18</text>
   <line x1="240.00000000000003" y1="31" x2="240.00000000000003" y2="223" class="line width"></line>
   <text x="240.00000000000003" y="28" class="font s5 text" text-anchor="middle">24</text>
-  <text x="240.00000000000003" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">24</text>
+  <text x="240.00000000000003" y="228" class="font s5 text" text-anchor="middle">24</text>
   <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
   <text x="290" y="28" class="font s5 text" text-anchor="middle">30</text>
-  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">30</text>
+  <text x="290" y="228" class="font s5 text" text-anchor="middle">30</text>
   <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="206" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="227" height="6" fill="#248ebd" rx="1" ry="1"></rect>

--- a/results/imgs/ember-quickstart.svg
+++ b/results/imgs/ember-quickstart.svg
@@ -9,31 +9,31 @@
     .text { fill: #888; }
   </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="14" class="font s4" text-anchor="middle">npm</text>
+  <text x="44" y="18" class="font s3" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="14" class="font s4" text-anchor="middle">yarn</text>
+  <text x="56" y="18" class="font s3" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="68" y="14" class="font s4" text-anchor="middle">pnpm</text>
+  <text x="68" y="18" class="font s3" text-anchor="middle">v2.13.0</text>
   <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
-  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <text x="40" y="228" class="font s5 text" text-anchor="middle">0</text>
   <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
   <text x="90" y="28" class="font s5 text" text-anchor="middle">8</text>
-  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">8</text>
+  <text x="90" y="228" class="font s5 text" text-anchor="middle">8</text>
   <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
   <text x="140" y="28" class="font s5 text" text-anchor="middle">16</text>
-  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">16</text>
+  <text x="140" y="228" class="font s5 text" text-anchor="middle">16</text>
   <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
   <text x="190" y="28" class="font s5 text" text-anchor="middle">24</text>
-  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">24</text>
+  <text x="190" y="228" class="font s5 text" text-anchor="middle">24</text>
   <line x1="240" y1="31" x2="240" y2="223" class="line width"></line>
   <text x="240" y="28" class="font s5 text" text-anchor="middle">32</text>
-  <text x="240" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">32</text>
+  <text x="240" y="228" class="font s5 text" text-anchor="middle">32</text>
   <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
   <text x="290" y="28" class="font s5 text" text-anchor="middle">40</text>
-  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">40</text>
+  <text x="290" y="228" class="font s5 text" text-anchor="middle">40</text>
   <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="143" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="217" height="6" fill="#248ebd" rx="1" ry="1"></rect>

--- a/results/imgs/ember-quickstart.svg
+++ b/results/imgs/ember-quickstart.svg
@@ -1,31 +1,40 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 237">
+  <style>
+    .font { font-family: sans-serif; }
+    .s3 { font-size: 3px; }
+    .s4 { font-size: 4px; }
+    .s5 { font-size: 5px; }
+    .line { stroke: #cacaca; }
+    .width { stroke-width: 0.5; }
+    .text { fill: #888; }
+  </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
+  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
+  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v2.13.0</text>
-  <text x="40" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">0</text>
-  <text x="40" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">0</text>
-  <line x1="90" y1="31" x2="90" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="90" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">8</text>
-  <text x="90" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">8</text>
-  <line x1="140" y1="31" x2="140" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="140" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">16</text>
-  <text x="140" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">16</text>
-  <line x1="190" y1="31" x2="190" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="190" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">24</text>
-  <text x="190" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">24</text>
-  <line x1="240" y1="31" x2="240" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="240" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">32</text>
-  <text x="240" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">32</text>
-  <line x1="290" y1="31" x2="290" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="290" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">40</text>
-  <text x="290" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">40</text>
-  <text x="290" y="20" font-size="4" font-family="system-ui" font-style="italic" text-anchor="end" fill="#888">Installation time in seconds (lower is better)</text>
+  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
+  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
+  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
+  <text x="90" y="28" class="font s5 text" text-anchor="middle">8</text>
+  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">8</text>
+  <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
+  <text x="140" y="28" class="font s5 text" text-anchor="middle">16</text>
+  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">16</text>
+  <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
+  <text x="190" y="28" class="font s5 text" text-anchor="middle">24</text>
+  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">24</text>
+  <line x1="240" y1="31" x2="240" y2="223" class="line width"></line>
+  <text x="240" y="28" class="font s5 text" text-anchor="middle">32</text>
+  <text x="240" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">32</text>
+  <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
+  <text x="290" y="28" class="font s5 text" text-anchor="middle">40</text>
+  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">40</text>
+  <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="143" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="217" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="48" width="180" height="6" fill="#fbae00" rx="1" ry="1"></rect>
@@ -50,19 +59,19 @@
   <rect x="40" y="199.5" width="44" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="206" width="226" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="212.5" width="163" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <line x1="40" y1="31" x2="40" y2="223" stroke-width="1" stroke="#cacaca"></line>
-  <text x="38" y="44.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">clean install</text>
-  <text x="38" y="64" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="68" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="72" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="89.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="93.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="115" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="138.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="160" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="164" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="183.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="187.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="209" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="290" y="235" font-size="4" font-family="system-ui" text-anchor="end" fill="#888">Tests were run using Node.js v10.6.0</text>
+  <line x1="40" y1="31" x2="40" y2="223" class="line"></line>
+  <text x="38" y="44.5" class="font s4" dominant-baseline="middle" text-anchor="end">clean install</text>
+  <text x="38" y="64" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="68" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="72" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="89.5" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="93.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="115" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="138.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="160" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="164" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="183.5" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="187.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="209" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="290" y="235" class="font s4 text" text-anchor="end">Tests were run using Node.js v10.6.0</text>
 </svg>

--- a/results/imgs/medium-size-app.svg
+++ b/results/imgs/medium-size-app.svg
@@ -9,31 +9,31 @@
     .text { fill: #888; }
   </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="14" class="font s4" text-anchor="middle">npm</text>
+  <text x="44" y="18" class="font s3" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="14" class="font s4" text-anchor="middle">yarn</text>
+  <text x="56" y="18" class="font s3" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="68" y="14" class="font s4" text-anchor="middle">pnpm</text>
+  <text x="68" y="18" class="font s3" text-anchor="middle">v2.13.0</text>
   <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
-  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <text x="40" y="228" class="font s5 text" text-anchor="middle">0</text>
   <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
   <text x="90" y="28" class="font s5 text" text-anchor="middle">6</text>
-  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">6</text>
+  <text x="90" y="228" class="font s5 text" text-anchor="middle">6</text>
   <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
   <text x="140" y="28" class="font s5 text" text-anchor="middle">12</text>
-  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">12</text>
+  <text x="140" y="228" class="font s5 text" text-anchor="middle">12</text>
   <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
   <text x="190" y="28" class="font s5 text" text-anchor="middle">18</text>
-  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">18</text>
+  <text x="190" y="228" class="font s5 text" text-anchor="middle">18</text>
   <line x1="240.00000000000003" y1="31" x2="240.00000000000003" y2="223" class="line width"></line>
   <text x="240.00000000000003" y="28" class="font s5 text" text-anchor="middle">24</text>
-  <text x="240.00000000000003" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">24</text>
+  <text x="240.00000000000003" y="228" class="font s5 text" text-anchor="middle">24</text>
   <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
   <text x="290" y="28" class="font s5 text" text-anchor="middle">30</text>
-  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">30</text>
+  <text x="290" y="228" class="font s5 text" text-anchor="middle">30</text>
   <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="183" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="218" height="6" fill="#248ebd" rx="1" ry="1"></rect>

--- a/results/imgs/medium-size-app.svg
+++ b/results/imgs/medium-size-app.svg
@@ -1,31 +1,40 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 237">
+  <style>
+    .font { font-family: sans-serif; }
+    .s3 { font-size: 3px; }
+    .s4 { font-size: 4px; }
+    .s5 { font-size: 5px; }
+    .line { stroke: #cacaca; }
+    .width { stroke-width: 0.5; }
+    .text { fill: #888; }
+  </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
+  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
+  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v2.13.0</text>
-  <text x="40" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">0</text>
-  <text x="40" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">0</text>
-  <line x1="90" y1="31" x2="90" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="90" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">6</text>
-  <text x="90" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">6</text>
-  <line x1="140" y1="31" x2="140" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="140" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">12</text>
-  <text x="140" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">12</text>
-  <line x1="190" y1="31" x2="190" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="190" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">18</text>
-  <text x="190" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">18</text>
-  <line x1="240.00000000000003" y1="31" x2="240.00000000000003" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="240.00000000000003" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">24</text>
-  <text x="240.00000000000003" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">24</text>
-  <line x1="290" y1="31" x2="290" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="290" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">30</text>
-  <text x="290" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">30</text>
-  <text x="290" y="20" font-size="4" font-family="system-ui" font-style="italic" text-anchor="end" fill="#888">Installation time in seconds (lower is better)</text>
+  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
+  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
+  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
+  <text x="90" y="28" class="font s5 text" text-anchor="middle">6</text>
+  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">6</text>
+  <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
+  <text x="140" y="28" class="font s5 text" text-anchor="middle">12</text>
+  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">12</text>
+  <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
+  <text x="190" y="28" class="font s5 text" text-anchor="middle">18</text>
+  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">18</text>
+  <line x1="240.00000000000003" y1="31" x2="240.00000000000003" y2="223" class="line width"></line>
+  <text x="240.00000000000003" y="28" class="font s5 text" text-anchor="middle">24</text>
+  <text x="240.00000000000003" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">24</text>
+  <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
+  <text x="290" y="28" class="font s5 text" text-anchor="middle">30</text>
+  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">30</text>
+  <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="183" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="218" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="48" width="140" height="6" fill="#fbae00" rx="1" ry="1"></rect>
@@ -50,19 +59,19 @@
   <rect x="40" y="199.5" width="60" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="206" width="224" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="212.5" width="123" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <line x1="40" y1="31" x2="40" y2="223" stroke-width="1" stroke="#cacaca"></line>
-  <text x="38" y="44.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">clean install</text>
-  <text x="38" y="64" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="68" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="72" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="89.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="93.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="115" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="138.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="160" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="164" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="183.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="187.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="209" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="290" y="235" font-size="4" font-family="system-ui" text-anchor="end" fill="#888">Tests were run using Node.js v10.6.0</text>
+  <line x1="40" y1="31" x2="40" y2="223" class="line"></line>
+  <text x="38" y="44.5" class="font s4" dominant-baseline="middle" text-anchor="end">clean install</text>
+  <text x="38" y="64" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="68" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="72" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="89.5" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="93.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="115" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="138.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="160" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="164" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="183.5" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="187.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="209" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="290" y="235" class="font s4 text" text-anchor="end">Tests were run using Node.js v10.6.0</text>
 </svg>

--- a/results/imgs/react-app.svg
+++ b/results/imgs/react-app.svg
@@ -9,31 +9,31 @@
     .text { fill: #888; }
   </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="14" class="font s4" text-anchor="middle">npm</text>
+  <text x="44" y="18" class="font s3" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="14" class="font s4" text-anchor="middle">yarn</text>
+  <text x="56" y="18" class="font s3" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="68" y="14" class="font s4" text-anchor="middle">pnpm</text>
+  <text x="68" y="18" class="font s3" text-anchor="middle">v2.13.0</text>
   <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
-  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <text x="40" y="228" class="font s5 text" text-anchor="middle">0</text>
   <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
   <text x="90" y="28" class="font s5 text" text-anchor="middle">5</text>
-  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">5</text>
+  <text x="90" y="228" class="font s5 text" text-anchor="middle">5</text>
   <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
   <text x="140" y="28" class="font s5 text" text-anchor="middle">10</text>
-  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">10</text>
+  <text x="140" y="228" class="font s5 text" text-anchor="middle">10</text>
   <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
   <text x="190" y="28" class="font s5 text" text-anchor="middle">15</text>
-  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">15</text>
+  <text x="190" y="228" class="font s5 text" text-anchor="middle">15</text>
   <line x1="240" y1="31" x2="240" y2="223" class="line width"></line>
   <text x="240" y="28" class="font s5 text" text-anchor="middle">20</text>
-  <text x="240" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">20</text>
+  <text x="240" y="228" class="font s5 text" text-anchor="middle">20</text>
   <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
   <text x="290" y="28" class="font s5 text" text-anchor="middle">25</text>
-  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">25</text>
+  <text x="290" y="228" class="font s5 text" text-anchor="middle">25</text>
   <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="223" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="221" height="6" fill="#248ebd" rx="1" ry="1"></rect>

--- a/results/imgs/react-app.svg
+++ b/results/imgs/react-app.svg
@@ -1,31 +1,40 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 237">
+  <style>
+    .font { font-family: sans-serif; }
+    .s3 { font-size: 3px; }
+    .s4 { font-size: 4px; }
+    .s5 { font-size: 5px; }
+    .line { stroke: #cacaca; }
+    .width { stroke-width: 0.5; }
+    .text { fill: #888; }
+  </style>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
-  <text x="44" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">npm</text>
-  <text x="44" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v6.3.0</text>
+  <text x="44" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">npm</text>
+  <text x="44" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v6.3.0</text>
   <circle cx="56" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="56" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">yarn</text>
-  <text x="56" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v1.9.4</text>
+  <text x="56" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">yarn</text>
+  <text x="56" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v1.9.4</text>
   <circle cx="68" cy="6" r="4" fill="#fbae00"></circle>
-  <text x="68" y="11" font-size="4" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">pnpm</text>
-  <text x="68" y="16" font-size="3" font-family="system-ui" alignment-baseline="hanging" text-anchor="middle">v2.13.0</text>
-  <text x="40" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">0</text>
-  <text x="40" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">0</text>
-  <line x1="90" y1="31" x2="90" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="90" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">5</text>
-  <text x="90" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">5</text>
-  <line x1="140" y1="31" x2="140" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="140" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">10</text>
-  <text x="140" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">10</text>
-  <line x1="190" y1="31" x2="190" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="190" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">15</text>
-  <text x="190" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">15</text>
-  <line x1="240" y1="31" x2="240" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="240" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">20</text>
-  <text x="240" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">20</text>
-  <line x1="290" y1="31" x2="290" y2="223" stroke-width="0.5" stroke="#cacaca"></line>
-  <text x="290" y="28" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle">25</text>
-  <text x="290" y="224" fill="#888" font-size="5" font-family="system-ui" text-anchor="middle" alignment-baseline="hanging">25</text>
-  <text x="290" y="20" font-size="4" font-family="system-ui" font-style="italic" text-anchor="end" fill="#888">Installation time in seconds (lower is better)</text>
+  <text x="68" y="11" class="font s4" dominant-baseline="hanging" text-anchor="middle">pnpm</text>
+  <text x="68" y="16" class="font s3" dominant-baseline="hanging" text-anchor="middle">v2.13.0</text>
+  <text x="40" y="28" class="font s5 text" text-anchor="middle">0</text>
+  <text x="40" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">0</text>
+  <line x1="90" y1="31" x2="90" y2="223" class="line width"></line>
+  <text x="90" y="28" class="font s5 text" text-anchor="middle">5</text>
+  <text x="90" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">5</text>
+  <line x1="140" y1="31" x2="140" y2="223" class="line width"></line>
+  <text x="140" y="28" class="font s5 text" text-anchor="middle">10</text>
+  <text x="140" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">10</text>
+  <line x1="190" y1="31" x2="190" y2="223" class="line width"></line>
+  <text x="190" y="28" class="font s5 text" text-anchor="middle">15</text>
+  <text x="190" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">15</text>
+  <line x1="240" y1="31" x2="240" y2="223" class="line width"></line>
+  <text x="240" y="28" class="font s5 text" text-anchor="middle">20</text>
+  <text x="240" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">20</text>
+  <line x1="290" y1="31" x2="290" y2="223" class="line width"></line>
+  <text x="290" y="28" class="font s5 text" text-anchor="middle">25</text>
+  <text x="290" y="224" class="font s5 text" text-anchor="middle" dominant-baseline="hanging">25</text>
+  <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="35" width="223" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="41.5" width="221" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="48" width="168" height="6" fill="#fbae00" rx="1" ry="1"></rect>
@@ -50,19 +59,19 @@
   <rect x="40" y="199.5" width="78" height="6" fill="#cd3731" rx="1" ry="1"></rect>
   <rect x="40" y="206" width="203" height="6" fill="#248ebd" rx="1" ry="1"></rect>
   <rect x="40" y="212.5" width="145" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <line x1="40" y1="31" x2="40" y2="223" stroke-width="1" stroke="#cacaca"></line>
-  <text x="38" y="44.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">clean install</text>
-  <text x="38" y="64" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="68" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="72" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="89.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="93.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="115" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="138.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="160" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with cache</text>
-  <text x="38" y="164" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="183.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="38" y="187.5" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with lockfile</text>
-  <text x="38" y="209" font-size="4" font-family="system-ui" alignment-baseline="middle" text-anchor="end">with node_modules</text>
-  <text x="290" y="235" font-size="4" font-family="system-ui" text-anchor="end" fill="#888">Tests were run using Node.js v10.6.0</text>
+  <line x1="40" y1="31" x2="40" y2="223" class="line"></line>
+  <text x="38" y="44.5" class="font s4" dominant-baseline="middle" text-anchor="end">clean install</text>
+  <text x="38" y="64" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="68" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="72" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="89.5" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="93.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="115" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="138.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="160" class="font s4" dominant-baseline="middle" text-anchor="end">with cache</text>
+  <text x="38" y="164" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="183.5" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="38" y="187.5" class="font s4" dominant-baseline="middle" text-anchor="end">with lockfile</text>
+  <text x="38" y="209" class="font s4" dominant-baseline="middle" text-anchor="end">with node_modules</text>
+  <text x="290" y="235" class="font s4 text" text-anchor="end">Tests were run using Node.js v10.6.0</text>
 </svg>


### PR DESCRIPTION
I've noticed that the text placement on Firefox was off. Also, the chosen font (`system-ui`) apparently doesn't work on all platforms and browsers. I've fixed it now and it seems to work fine on Chrome, Firefox, and Safari on macOS.

But for Windows and Linux I haven't checked it out. If somebody else could verify that it looks good on those OSes and their browsers, that would be great. [Here](https://github.com/nikoladev/node-package-manager-benchmark/tree/all-browsers) you can take a look at the graphs.